### PR TITLE
Pull request template tweaks

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,14 +3,14 @@
 <!-- Fixes #xxx. -->
 <!-- See #xxx. -->
 
+### How to test
+<!-- Detailed steps to test this PR. -->
+1. 
+
 ### Documentation
 <!-- No documentation required. -->
 <!-- Documentation required. See #xxx. -->
 <!-- PR includes documentation. -->
-
-### How to test
-<!-- Detailed steps to test this PR. -->
-1. 
 
 ### Suggested changelog entry
 <!-- A short description for the changelog. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,3 @@
-<!--
-Thank you so much for submitting your contribution!
-
-A couple things:
-
-First, anything wrapped in HTML comment tags will be ignored when you submit. So don't feel like you need to remove them before submitting, but you can if you want to. And make sure anything you **want** to be seen is **not** between HTML comment tags.
-
-Second, any PR that you submit will be automatically:
-
-- linted for syntax errors
-- scanned for code standards violations
-- checked from failing tests with the bundled test suite
-
-If any of these fail, expect a reviewer to ask you to correct the errors before this PR can be approved.
-
-Thanks!
--->
 **Summary of change:**
 <!-- Provide a short but detailed summary of the changes included in this PR -->
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,21 @@
-**Summary of change:**
-<!-- Provide a short but detailed summary of the changes included in this PR -->
+### Summary
+<!-- A short but detailed summary of the changes. -->
 
-**Have the changes in this PR been added to the documentation for this project?**
-<!--
-Yes / No / Does not apply
-(if No, please create and link to the issue that identifies the need for documentation)
--->
+<!-- Fixes #xxx. -->
+<!-- See #xxx. -->
 
-**How to test:**
-<!-- Provide as detailed a description for how to test this PR. -->
+### Documentation
+<!-- No documentation required. -->
+<!-- Documentation required. See #xxx. -->
+<!-- PR includes documentation. -->
 
-<!-- If this PR is in reference to an existing issue, link it here. -->
-**See:** #xxx
+### How to test
+<!-- Detailed steps to test this PR. -->
+1. 
 
-<!-- If this PR fully resolves an existing issue, link it here. -->
-**Fixes:** #xxx
+### Suggested changelog entry
+<!-- A short description for the changelog. -->
+- 
 
-**Suggested Changelog Entry:**
-<!-- Provide a short description of the changes in this PR for inclusion in the changelog. -->
-
-<!-- You can use this space to provide any additional information that may be relevant to this PR -->
+### Notes
+<!-- Additional information for reviewers. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-### Summary
 <!-- A short but detailed summary of the changes. -->
 
 <!-- Fixes #xxx. -->


### PR DESCRIPTION
Fixes #2 by:

- Removing the PR template intro text. Regular contributors don't need to see this each time they open a PR. For first-time contributors, we could add a `contributing.md` file with info specific to each repo.
- Shortens titles and sections.
- Uses markdown header markup instead of bold headers, which can make PRs easier to structure.