### PR TITLE
Remove PR template headings we don't use

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,7 @@
 <!-- A short but detailed summary of the changes. -->
 
 <!-- Fixes #xxx. -->
-<!-- See #xxx. -->
 
 ### How to test
 <!-- Detailed steps to test this PR. -->
-1. 
-
-### Documentation
-<!-- No documentation required. -->
-<!-- Documentation required. See #xxx. -->
-<!-- PR includes documentation. -->
-
-### Suggested changelog entry
-<!-- A short description for the changelog. -->
-- 
-
-### Notes
-<!-- Additional information for reviewers. -->
+1.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,8 @@
 ### How to test
 <!-- Detailed steps to test this PR. -->
 1.
+
+### Documentation
+<!-- No documentation required. -->
+<!-- Documentation required. See #xxx. -->
+<!-- PR includes documentation. -->


### PR DESCRIPTION
What do you think about removing these PR template headings we rarely use?

If we really need them, we can manually add them.

