### PR TITLE
Add to the PR template that we're not accepting community PRs anymore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- We'll respond to big bugs, but probably not smaller ones. -->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,4 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+Thanks, but we're not adding new features.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+## Tasks
+
+- [ ] I am a WP Engine employee (sorry, we're not accepting community contributions anymore).
+
 <!-- A short but detailed summary of the changes. -->
 
 <!-- Fixes #xxx. -->


### PR DESCRIPTION
* Add to the PR template that we're not accepting community PRs anymore
* State that we're not adding new features
* GCB has [something similar](https://github.com/studiopress/genesis-custom-blocks/blob/7f9c43d994ff5d9d1ac9728498015403cc503371/.github/ISSUE_TEMPLATE/feature_request.md)

### How to test
Not needed